### PR TITLE
ci(zizmor): enforce high/high GitHub Actions security gate

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,28 @@
+name: zizmor GitHub Actions security analysis
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # needed for checkout
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          advanced-security: false
+          min-severity: high
+          min-confidence: high


### PR DESCRIPTION
Rolls out the org [zizmor policy](https://github.com/feedbackfruits/feedbackfruits-devsecops/blob/main/policies/zizmor.md) to this repo.

Adds `.github/workflows/zizmor.yml`: SHA-pinned steps, top-level `permissions: {}`, `advanced-security: false`, gated at `min-severity: high` / `min-confidence: high`, running on all pull requests and on pushes to `main`.

**Opened as draft on purpose.** Its own zizmor check is the authoritative scan of this repo's existing workflows. If the check fails, those findings are pre-existing high/high debt and get fixed in separate `fix/zizmor-*` PRs first (policy rollout order: remediate, then enforce). This PR is marked ready for review only once the gate is green.

Tracking: feedbackfruits/feedbackfruits-devsecops#4