### PR TITLE
fix(ci): pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Fetch dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Auto-approve minor/patch bumps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
     name: Release (GH)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Enable Corepack
         run: corepack enable
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           registry-url: https://npm.pkg.github.com
           node-version: ${{ env.NODE_VERSION }}
@@ -36,10 +36,10 @@ jobs:
     name: Release (NPM)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Enable Corepack
         run: corepack enable
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           registry-url: 'https://registry.npmjs.org'
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
     name: Chewtoy validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Enable Corepack
         run: corepack enable
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'


### PR DESCRIPTION
Remediates all `unpinned-uses` findings so this repo can adopt the org [zizmor policy](https://github.com/feedbackfruits/feedbackfruits-devsecops/blob/main/policies/zizmor.md) gate.

**What:** every `uses:` reference in `.github/workflows/` is pinned to a full commit SHA, with the original tag/branch preserved as a trailing comment.

**Why:** a tag or branch ref is mutable — whoever controls it can swap in different code that runs with this workflow's `GITHUB_TOKEN` and secrets. zizmor rates this high severity / high confidence.

**Risk:** behaviour preserving. Each SHA is the commit the referenced ref points at today, so no version changes. Dependabot still recognises the `# <ref>` comment and will keep proposing upgrades.

Blocks: the enforcement PR on this repo (`ci/zizmor-enforce-high-gate`), which stays draft until the gate is green.

Tracking: feedbackfruits/feedbackfruits-devsecops#4
