### PR TITLE
fix(ci): use the PR author, not github.actor, to detect Dependabot

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == github.event.pull_request.head.repo.full_name }}
     steps:
       - name: Fetch dependabot metadata
         id: metadata


### PR DESCRIPTION
Remediates the `bot-conditions` finding so this repo can adopt the org [zizmor policy](https://github.com/feedbackfruits/feedbackfruits-devsecops/blob/main/policies/zizmor.md) gate.

**What:**
```diff
-if: ${{ github.actor == 'dependabot[bot]' }}
+if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == github.event.pull_request.head.repo.full_name }}
```

**Why:** `github.actor` reflects whoever triggered the *most recent* event, not the PR author. A human re-running this workflow (or pushing to the Dependabot branch) satisfies the check, so the auto-approve + auto-merge steps can be reached for a PR Dependabot didn't open. `github.event.pull_request.user.login` is the real author; the `github.repository == ...head.repo.full_name` clause additionally rules out fork PRs.

**Risk:** none for genuine Dependabot PRs — they are authored by `dependabot[bot]` and branch within the repo, so the guard still passes. Identical to the condition already running on data-api, feedbackfruits-media and lms-ruby.

Blocks: the enforcement PR on this repo (`ci/zizmor-enforce-high-gate`), which stays draft until the gate is green.

Tracking: feedbackfruits/feedbackfruits-devsecops#4
