### PR TITLE
fix(ci): scope release workflow permissions to the jobs that need them

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,7 @@ on:
       - main
       - master
 
-permissions:
-  id-token: write
-  contents: write
-  packages: write
+permissions: {}
 
 env:
   NODE_VERSION: '24'
@@ -18,6 +15,9 @@ jobs:
   release:
     name: Release (GH)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # needed for checkout
+      packages: write # needed to publish to GitHub Packages
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Enable Corepack
@@ -35,6 +35,9 @@ jobs:
   release-npm:
     name: Release (NPM)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # needed for checkout
+      id-token: write # needed for npm trusted publishing (OIDC)
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Enable Corepack


### PR DESCRIPTION
Remediates the `excessive-permissions` findings so this repo can adopt the org [zizmor policy](https://github.com/feedbackfruits/feedbackfruits-devsecops/blob/main/policies/zizmor.md) gate (requirement 5: least-privilege `permissions`).

**What:** `.github/workflows/release.yml` drops its workflow-level `permissions:` block for `permissions: {}`, and each job declares what it actually needs:

| job | permissions | why |
|---|---|---|
| `Release (GH)` | `contents: read`, `packages: write` | checkout + `npm publish` to `npm.pkg.github.com` |
| `Release (NPM)` | `contents: read`, `id-token: write` | checkout + npm trusted publishing (OIDC) |

**Why:** workflow-level grants apply to every job and every action inside it. A compromised transitive dependency in the npm job currently gets `packages: write` too, and vice versa.

**Risk:** `contents: write` is removed — verified that neither job pushes commits, tags or GitHub releases, they only check out and publish. Everything else is preserved, just narrowed to the job that uses it.

Blocks: the enforcement PR on this repo (`ci/zizmor-enforce-high-gate`), which stays draft until the gate is green.

Tracking: feedbackfruits/feedbackfruits-devsecops#4
