### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @FeedbackFruits/core-tech


### PR DESCRIPTION
### 💡 Summary

Adds `.github/CODEOWNERS` naming `@FeedbackFruits/core-tech` as the default owner for every path in this repo. No repo in the [devsecops scope](https://github.com/feedbackfruits/feedbackfruits-devsecops/blob/main/repos.txt) had a CODEOWNERS file, so review requests have been going to whoever the author happened to pick, and there was no recorded answer to who owns this code.

### 🛠️ What does this PR do?

- Owner is `@FeedbackFruits/core-tech` because shared org-wide toolchain config; `core-tech` already holds admin.
- Owner is a **team**, not an individual: a named person stalls review whenever they are away, and silently goes stale as people change roles. Team membership is already maintained in one place.
- A single global `*` rule rather than per-path ownership — this repo has no subtree with a genuinely different owner, and a one-line file stays correct as the tree moves.
- **Merging this alone changes nothing enforceable.** CODEOWNERS only gates merges once branch protection enables *Require review from Code Owners*; until then it just pre-fills reviewer suggestions. Flipping that switch is deliberately left out of this PR so the reviewer assignment can settle first.
