### PR TITLE
fix(deps): re-resolve js-yaml onto a patched version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -839,8 +839,8 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -1224,7 +1224,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -2082,7 +2082,7 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
### 💡 Summary

Moves `js-yaml` onto a patched version to close the Dependabot alerts below. The patched version already sits inside the range the manifests allow, so only the lockfile changes.

- [#33](https://github.com/feedbackfruits/eslint-config/security/dependabot/33) high — JS-YAML: Quadratic CPU consumption in !!omap resolution (3.x and 4.x) — CVE-2026-59870 fix not backported (GHSA-5p4m-2wfm-xmqj), fixed in 4.3.1

Dependabot cannot open this PR. It bumps a transitive dependency only when it can bump the parent pinning it, so these alerts stay open even though the fix is published.

### 🛠️ What does this PR do?

- Re-resolves the lockfile with the repo's own package manager, limited to `js-yaml`.
- `audit` counts 3 actionable advisories before and 2 after. What remains belongs to other packages, each handled in its own PR.
- Touches no manifest, source, or workflow file. Had the re-resolve required one, this PR would not have been opened.

GitHub closes the alerts once this lands on `main`.

Generated by [`fix_lockfile.sh`](https://github.com/feedbackfruits/feedbackfruits-devsecops/blob/main/.claude/skills/dependabot-alert-audit/scripts/fix_lockfile.sh) in [feedbackfruits-devsecops](https://github.com/feedbackfruits/feedbackfruits-devsecops).
